### PR TITLE
Cr ma estimated purchase date

### DIFF
--- a/src/components/FormProduct/index.jsx
+++ b/src/components/FormProduct/index.jsx
@@ -10,6 +10,7 @@ export const FormProduct = () => {
     item: '',
     nextPurchase: 0,
     lastPurchasedDate: null,
+    numberOfPurchases: 0,
   };
 
   const [product, setProduct] = useState(initialStateProduct);
@@ -26,7 +27,7 @@ export const FormProduct = () => {
       ) : (
         <span aria-live="polite">All fields are required</span>
       ),
-    ); 
+    );
   };
   const handleSubmitProduct = (e) => {
     e.preventDefault();

--- a/src/components/FormProduct/index.jsx
+++ b/src/components/FormProduct/index.jsx
@@ -11,7 +11,7 @@ export const FormProduct = () => {
     nextPurchase: 0,
     lastPurchasedDate: null,
     numberOfPurchases: 0,
-    estimatesDaysNextPurchased: 0,
+    estimatedDaysNextPurchase: 0,
   };
 
   const [product, setProduct] = useState(initialStateProduct);

--- a/src/components/FormProduct/index.jsx
+++ b/src/components/FormProduct/index.jsx
@@ -11,7 +11,7 @@ export const FormProduct = () => {
     nextPurchase: 0,
     lastPurchasedDate: null,
     numberOfPurchases: 0,
-    estimatedDaysNextPurchase: 0,
+    estimatedDaysNextPurchase: null,
   };
 
   const [product, setProduct] = useState(initialStateProduct);

--- a/src/components/FormProduct/index.jsx
+++ b/src/components/FormProduct/index.jsx
@@ -11,6 +11,7 @@ export const FormProduct = () => {
     nextPurchase: 0,
     lastPurchasedDate: null,
     numberOfPurchases: 0,
+    estimatesDaysNextPurchased: 0,
   };
 
   const [product, setProduct] = useState(initialStateProduct);

--- a/src/components/ItemList/index.jsx
+++ b/src/components/ItemList/index.jsx
@@ -8,6 +8,7 @@ function ItemList({
   nextPurchase,
   lastPurchasedDate,
   numberOfPurchases,
+  estimatedDaysNextPurchase,
 }) {
   const [isChecked, setIsChecked] = useState(false);
   const [isDisabled, setIsDisabled] = useState(false);
@@ -36,17 +37,18 @@ function ItemList({
   const latestInterval = () => {
     const currentDate = +new Date();
     const oneDay = 60 * 60 * 24 * 1000;
-    return Math.floor((currentDate - formattedDate) / oneDay);
+    const dayInterval = Math.floor((currentDate - formattedDate) / oneDay);
+    return numberOfPurchases === 0 ? nextPurchase : dayInterval;
   };
   const dayLatestInterval = latestInterval();
 
-  const estimatesDaysNextPurchased = calculateEstimate(
-    nextPurchase,
+  const estimatedNextPurchase = calculateEstimate(
+    estimatedDaysNextPurchase,
     dayLatestInterval,
     numberOfPurchases,
   );
   const MarkProductPurchased = (id) => {
-    updateItemDate(token, id, numberOfPurchases, estimatesDaysNextPurchased)
+    updateItemDate(token, id, numberOfPurchases, estimatedNextPurchase)
       .then(() => {
         console.log('product updated');
       })

--- a/src/components/ItemList/index.jsx
+++ b/src/components/ItemList/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { updateItemDate } from '../Utils/firestore';
 import { isWithin24hours, latestInterval } from 'components/Utils/helpers';
-const { default: calculateEstimate } = require('lib/estimates');
+import calculateEstimate from 'lib/estimates';
 function ItemList({
   itemName,
   docId,
@@ -33,7 +33,7 @@ function ItemList({
   const isDateValid = (date) => {
     if (date) return true;
   };
-  const MarkProductPurchased = (
+  const markProductPurchased = (
     id,
     lastPurchasedDateMillis,
     nextPurchaseEstimatedByUser,
@@ -65,7 +65,7 @@ function ItemList({
     setIsChecked(!isChecked);
 
     if (event.target.checked) {
-      MarkProductPurchased(
+      markProductPurchased(
         docId,
         formattedDate,
         nextPurchase,

--- a/src/components/ItemList/index.jsx
+++ b/src/components/ItemList/index.jsx
@@ -33,20 +33,26 @@ function ItemList({
   const isDateValid = (date) => {
     if (date) return true;
   };
+  const MarkProductPurchased = (
+    id,
+    lastPurchasedDateMillis,
+    nextPurchaseEstimatedByUser,
+    actualNumberOfPurchases,
+    lastEstimateNextPurchase,
+  ) => {
+    const daysLatestInterval = latestInterval(
+      lastPurchasedDateMillis,
+      actualNumberOfPurchases,
+      nextPurchaseEstimatedByUser,
+    );
 
-  const dayLatestInterval = latestInterval(
-    formattedDate,
-    numberOfPurchases,
-    nextPurchase,
-  );
+    const estimatedNextPurchase = calculateEstimate(
+      lastEstimateNextPurchase,
+      daysLatestInterval,
+      actualNumberOfPurchases,
+    );
 
-  const estimatedNextPurchase = calculateEstimate(
-    estimatedDaysNextPurchase,
-    dayLatestInterval,
-    numberOfPurchases,
-  );
-  const MarkProductPurchased = (id) => {
-    updateItemDate(token, id, numberOfPurchases, estimatedNextPurchase)
+    updateItemDate(token, id, actualNumberOfPurchases, estimatedNextPurchase)
       .then(() => {
         console.log('product updated');
       })
@@ -59,7 +65,13 @@ function ItemList({
     setIsChecked(!isChecked);
 
     if (event.target.checked) {
-      MarkProductPurchased(docId);
+      MarkProductPurchased(
+        docId,
+        formattedDate,
+        nextPurchase,
+        numberOfPurchases + 1,
+        estimatedDaysNextPurchase,
+      );
       setIsDisabled(true);
     }
   };

--- a/src/components/ItemList/index.jsx
+++ b/src/components/ItemList/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { updateItemDate } from '../Utils/firestore';
-import { isWithin24hours } from 'components/Utils/helpers';
+import { isWithin24hours, latestInterval } from 'components/Utils/helpers';
 const { default: calculateEstimate } = require('lib/estimates');
 function ItemList({
   itemName,
@@ -34,13 +34,11 @@ function ItemList({
     if (date) return true;
   };
 
-  const latestInterval = () => {
-    const currentDate = +new Date();
-    const oneDay = 60 * 60 * 24 * 1000;
-    const dayInterval = Math.floor((currentDate - formattedDate) / oneDay);
-    return numberOfPurchases === 0 ? nextPurchase : dayInterval;
-  };
-  const dayLatestInterval = latestInterval();
+  const dayLatestInterval = latestInterval(
+    formattedDate,
+    numberOfPurchases,
+    nextPurchase,
+  );
 
   const estimatedNextPurchase = calculateEstimate(
     estimatedDaysNextPurchase,

--- a/src/components/ProductList/index.jsx
+++ b/src/components/ProductList/index.jsx
@@ -11,7 +11,9 @@ function ProductList({ products }) {
               <ItemList
                 itemName={doc.data().item}
                 docId={doc.id}
+                nextPurchase={doc.data().nextPurchase}
                 lastPurchasedDate={doc.data().lastPurchasedDate || ''}
+                numberOfPurchases={doc.data().numberOfPurchases}
               />
             </div>
           ))}

--- a/src/components/ProductList/index.jsx
+++ b/src/components/ProductList/index.jsx
@@ -14,6 +14,7 @@ function ProductList({ products }) {
                 nextPurchase={doc.data().nextPurchase}
                 lastPurchasedDate={doc.data().lastPurchasedDate || ''}
                 numberOfPurchases={doc.data().numberOfPurchases}
+                estimatedDaysNextPurchase={doc.data().estimatedDaysNextPurchase}
               />
             </div>
           ))}

--- a/src/components/Utils/estimatedPurchaseDate.js
+++ b/src/components/Utils/estimatedPurchaseDate.js
@@ -1,0 +1,3 @@
+const { default: calculateEstimate } = require('lib/estimates');
+
+calculateEstimate(4.5, 2, 2);

--- a/src/components/Utils/estimatedPurchaseDate.js
+++ b/src/components/Utils/estimatedPurchaseDate.js
@@ -1,3 +1,0 @@
-const { default: calculateEstimate } = require('lib/estimates');
-
-calculateEstimate(4.5, 2, 2);

--- a/src/components/Utils/firestore.js
+++ b/src/components/Utils/firestore.js
@@ -27,12 +27,9 @@ export const updateItemDate = (
   numberOfPurchases,
   estimatedDaysNextPurchase,
 ) => {
-  return db
-    .collection(token)
-    .doc(id)
-    .update({
-      lastPurchasedDate: new Date(),
-      numberOfPurchases: numberOfPurchases + 1,
-      estimatedDaysNextPurchase: estimatedDaysNextPurchase,
-    });
+  return db.collection(token).doc(id).update({
+    lastPurchasedDate: new Date(),
+    numberOfPurchases: numberOfPurchases,
+    estimatedDaysNextPurchase: estimatedDaysNextPurchase,
+  });
 };

--- a/src/components/Utils/firestore.js
+++ b/src/components/Utils/firestore.js
@@ -1,4 +1,5 @@
 import { db } from 'lib/firebase';
+
 //Create a product in the dataBase
 export const addProduct = (objectProduct) => {
   const token = localStorage.getItem('tcl18-token');
@@ -31,7 +32,7 @@ export const updateItemDate = (
     .doc(id)
     .update({
       lastPurchasedDate: new Date(),
-      numberOfPurchases: numberOfPurchases + 1,
+      numberOfPurchases: Number(numberOfPurchases) + 1,
       estimatesDaysNextPurchased: estimatesDaysNextPurchased,
     });
 };

--- a/src/components/Utils/firestore.js
+++ b/src/components/Utils/firestore.js
@@ -24,7 +24,7 @@ export const updateItemDate = (
   token,
   id,
   numberOfPurchases,
-  estimatesDaysNextPurchased,
+  estimatedDaysNextPurchase,
 ) => {
   return db
     .collection(token)
@@ -32,6 +32,6 @@ export const updateItemDate = (
     .update({
       lastPurchasedDate: new Date(),
       numberOfPurchases: numberOfPurchases + 1,
-      estimatesDaysNextPurchased: estimatesDaysNextPurchased,
+      estimatedDaysNextPurchase: estimatedDaysNextPurchase,
     });
 };

--- a/src/components/Utils/firestore.js
+++ b/src/components/Utils/firestore.js
@@ -20,6 +20,18 @@ export const existCollectionByToken = async (userToken) => {
   }
 };
 
-export const updateItemDate = (token, id) => {
-  return db.collection(token).doc(id).update({ lastPurchasedDate: new Date() });
+export const updateItemDate = (
+  token,
+  id,
+  numberOfPurchases,
+  estimatesDaysNextPurchased,
+) => {
+  return db
+    .collection(token)
+    .doc(id)
+    .update({
+      lastPurchasedDate: new Date(),
+      numberOfPurchases: numberOfPurchases + 1,
+      estimatesDaysNextPurchased: estimatesDaysNextPurchased,
+    });
 };

--- a/src/components/Utils/firestore.js
+++ b/src/components/Utils/firestore.js
@@ -32,7 +32,7 @@ export const updateItemDate = (
     .doc(id)
     .update({
       lastPurchasedDate: new Date(),
-      numberOfPurchases: Number(numberOfPurchases) + 1,
+      numberOfPurchases: numberOfPurchases + 1,
       estimatesDaysNextPurchased: estimatesDaysNextPurchased,
     });
 };

--- a/src/components/Utils/helpers.js
+++ b/src/components/Utils/helpers.js
@@ -22,9 +22,14 @@ export const isWithin24hours = (lastPurchasedDate) => {
   return isOutdated;
 };
 
-export const latestInterval = (lastDateToMillis, numberOfPurchases) => {
+export const latestInterval = (
+  lastDateToMillis,
+  numberOfPurchases,
+  nextPurchaseEstimatedByUser,
+) => {
   const currentDate = +new Date();
   const oneDay = 60 * 60 * 24 * 1000;
   const dayInterval = Math.floor((currentDate - lastDateToMillis) / oneDay);
-  return numberOfPurchases === 0 || numberOfPurchases < 2 ? null : dayInterval;
+  const isFirstPurchase = numberOfPurchases === 1;
+  return isFirstPurchase ? nextPurchaseEstimatedByUser : dayInterval;
 };

--- a/src/components/Utils/helpers.js
+++ b/src/components/Utils/helpers.js
@@ -22,13 +22,9 @@ export const isWithin24hours = (lastPurchasedDate) => {
   return isOutdated;
 };
 
-export const latestInterval = (
-  lastDateToMillis,
-  numberOfPurchases,
-  nextPurchase,
-) => {
+export const latestInterval = (lastDateToMillis, numberOfPurchases) => {
   const currentDate = +new Date();
   const oneDay = 60 * 60 * 24 * 1000;
   const dayInterval = Math.floor((currentDate - lastDateToMillis) / oneDay);
-  return numberOfPurchases === 0 ? nextPurchase : dayInterval;
+  return numberOfPurchases === 0 || numberOfPurchases < 2 ? null : dayInterval;
 };

--- a/src/components/Utils/helpers.js
+++ b/src/components/Utils/helpers.js
@@ -21,3 +21,14 @@ export const isWithin24hours = (lastPurchasedDate) => {
   const isOutdated = currentDate - lastPurchasedDate > oneDay;
   return isOutdated;
 };
+
+export const latestInterval = (
+  lastDateToMillis,
+  numberOfPurchases,
+  nextPurchase,
+) => {
+  const currentDate = +new Date();
+  const oneDay = 60 * 60 * 24 * 1000;
+  const dayInterval = Math.floor((currentDate - lastDateToMillis) / oneDay);
+  return numberOfPurchases === 0 ? nextPurchase : dayInterval;
+};

--- a/src/lib/estimates.js
+++ b/src/lib/estimates.js
@@ -1,6 +1,5 @@
 /**
- * Calculate a weighted estimate for the interval until the next purchase
- * Current purchase a tiny bit less weight than all previous purchases
+ *
  *
  * @param {Number} lastEstimate The last estimated purchase interval
  * @param {Number} latestInterval The number of days between the most recent and previous purchases
@@ -9,17 +8,17 @@
  * @return {Number} Estimated number of days until the next purchase
  */
 const calculateEstimate = (lastEstimate, latestInterval, numberOfPurchases) => {
-    if (numberOfPurchases >= 2) {
-        if (isNaN(lastEstimate)) {
-            lastEstimate = 14;
-        }
-        let previousFactor = lastEstimate * numberOfPurchases;
-        let latestFactor = latestInterval * (numberOfPurchases - 1);
-        let totalDivisor = numberOfPurchases * 2 - 1;
-        return Math.round((previousFactor + latestFactor) / totalDivisor);
-    } else {
-        return latestInterval;
+  if (numberOfPurchases >= 2) {
+    if (isNaN(lastEstimate)) {
+      lastEstimate = 14;
     }
+    let previousFactor = lastEstimate * numberOfPurchases;
+    let latestFactor = latestInterval * (numberOfPurchases - 1);
+    let totalDivisor = numberOfPurchases * 2 - 1;
+    return Math.round((previousFactor + latestFactor) / totalDivisor);
+  } else {
+    return latestInterval;
+  }
 };
 
 export default calculateEstimate;


### PR DESCRIPTION
## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |

## Related Issue

Fix #10

## Description

As an item, I want my estimated next purchase date to be computed at the time my purchase is recorded in the database so the app can learn how often I buy different items.

## Acceptance Criteria

- [ ] When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database.
- [ ] The script at /src/lib/estimates.js should be used to calculate the next estimated purchase interval.

### Image Database
#### Description: 
Two new fields were added to the database: 
- EstimatedDateNextPurchased: which in the first purchase will be the value corresponding to NextPurchase, and in subsequent purchases, it calculates a weighted estimate for the interval until the next purchase.
- numberOfPurchases: that corresponds to the total number of purchases of the item.

<img width="446" alt="Screen Shot 2021-02-02 at 11 48 40 AM" src="https://user-images.githubusercontent.com/54448243/106633240-9bc17980-654c-11eb-8bb6-64215f8aa22b.png">


